### PR TITLE
Fix page width on What's new and about pages

### DIFF
--- a/app/views/UR rounds/Round 12/ef-about.html
+++ b/app/views/UR rounds/Round 12/ef-about.html
@@ -102,7 +102,7 @@
   About
 </h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
 
     <h2 class="govuk-heading-m">New view parent finances service available April 2025</h2>
       <p class="govuk-body">View parent finances (VPF) service makes it easier for you to understand paying parents' finances and see the complete picture from the start of the case to the current date. </p> 

--- a/app/views/UR rounds/Round 12/ef-whatsnew.html
+++ b/app/views/UR rounds/Round 12/ef-whatsnew.html
@@ -102,7 +102,7 @@
   What’s new
 </h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
 
     <div class="updates-form-group">
       <div id="more-detail-hint" class="govuk-hint">

--- a/app/views/sprintDevelopment/sprint 39/ef-about.html
+++ b/app/views/sprintDevelopment/sprint 39/ef-about.html
@@ -102,7 +102,7 @@
   About
 </h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">View parent finances (VPF) uses data from CMS2012.</p> 
 
     <h2 class="govuk-heading-m">Limited access to VPF</h2>

--- a/app/views/sprintDevelopment/sprint 39/ef-whatsnew.html
+++ b/app/views/sprintDevelopment/sprint 39/ef-whatsnew.html
@@ -102,13 +102,13 @@
   What’s new
 </h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
 
        <div class="updates-form-group">
       <div id="more-detail-hint" class="govuk-hint">
         14 April 2025
       </div>
-      <h2 class="govuk-heading-s">View parent finances features </h2>
+      <h2 class="govuk-heading-m">View parent finances features </h2>
       <p class="govuk-body">This version includes:</p>
       <ul class="govuk-list">
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/sprintDevelopment/sprint 40/ef-about.html
+++ b/app/views/sprintDevelopment/sprint 40/ef-about.html
@@ -102,7 +102,7 @@
   About
 </h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">View parent finances (VPF) uses data from CMS2012.</p> 
 
     <h2 class="govuk-heading-m">Limited access to VPF</h2>

--- a/app/views/sprintDevelopment/sprint 40/ef-whatsnew.html
+++ b/app/views/sprintDevelopment/sprint 40/ef-whatsnew.html
@@ -102,13 +102,13 @@
   What’s new
 </h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
 
        <div class="updates-form-group">
       <div id="more-detail-hint" class="govuk-hint">
         14 April 2025
       </div>
-      <h2 class="govuk-heading-s">View parent finances features </h2>
+      <h2 class="govuk-heading-m">View parent finances features </h2>
       <p class="govuk-body">This version includes:</p>
       <ul class="govuk-list">
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Was full width not 2/3rds. Also made what's new item headings h2 so didn't miss a  heading level out.